### PR TITLE
Corrected the order in which tar options are specified.

### DIFF
--- a/roles/deploy-manage-tools/files/admin-tools/12_BackupMaterials.ipynb
+++ b/roles/deploy-manage-tools/files/admin-tools/12_BackupMaterials.ipynb
@@ -348,7 +348,7 @@
     "  echo ${entry} >>\"${EXCLUDE_LIST}\"\n",
     "done\n",
     "\n",
-    "tar -cz -C ~ -T <(sort -u \"${TARGET_LIST}\") -X <(sort -u \"${EXCLUDE_LIST}\") -f \"${TGZ_FILE}\"\n",
+    "tar -cz -C ~ -X <(sort -u \"${EXCLUDE_LIST}\") -T <(sort -u \"${TARGET_LIST}\") -f \"${TGZ_FILE}\"\n",
     "mv \"${TGZ_FILE}\" ~/\n",
     "rm -rf \"${TMP_WORK_DIR}\"\n",
     "\n",


### PR DESCRIPTION
I get an error when I run the tar command for backup. Recent gnu tar commands give the following error if '-X' is not specified in the correct order.

> tar: The following options were used after any non-optional arguments in archive create or update mode.  These options are positional and affect only arguments that follow them.  Please, rearrange them properly.

Changed the order in which '-X' options are specified to avoid errors.
